### PR TITLE
fix: duplicate asset creation

### DIFF
--- a/src/components/form/assetselector/AssetSelector.tsx
+++ b/src/components/form/assetselector/AssetSelector.tsx
@@ -131,6 +131,7 @@ export default class AssetSelector extends React.Component<AssetSelectorProps, A
       if (toCreate) {
         // filter it out
         selected = selected.filter((option: any) => !option.arbitrary);
+        this.props.onChange(selected);
         this.handleCreateOption(toCreate.name);
       } else {
         this.props.onChange(selected);

--- a/src/temba/TembaSelect.tsx
+++ b/src/temba/TembaSelect.tsx
@@ -177,13 +177,15 @@ export class TembaSelect extends React.Component<TembaSelectProps, TembaSelectSt
   }
 
   private setAvailableOptions(options: any[]) {
+    const nameKey = this.props.nameKey || 'name';
+    const valueKey = this.props.valueKey || 'value';
     const remmapedOptions = options.map((option: any) => {
       const newOption = { ...option, value: this.getValue(option) };
-      if (!newOption[this.props.nameKey]) {
-        newOption[this.props.nameKey] = this.getName(option);
+      if (!newOption[nameKey]) {
+        newOption[nameKey] = this.getName(option);
       }
-      if (!newOption[this.props.valueKey]) {
-        newOption[this.props.valueKey] = this.getValue(option);
+      if (!newOption[valueKey]) {
+        newOption[valueKey] = this.getValue(option);
       }
       return newOption;
     });


### PR DESCRIPTION
- Emitting selected element change after arbitrary option is filtered out
- Better handle of setAvailableOptions mapping