### PR TITLE
fix: parse float in flow definition loading

### DIFF
--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -326,6 +326,11 @@ export const loadFlowDefinition = (details: FlowDetails, assetStore: AssetStore)
         type: guessNodeType(node)
       };
       currentTop += 150;
+    } else {
+      definition._ui.nodes[node.uuid].position = {
+        left: parseFloat(definition._ui.nodes[node.uuid].position.left as any),
+        top: parseFloat(definition._ui.nodes[node.uuid].position.top as any)
+      };
     }
   }
 


### PR DESCRIPTION
- Some positions are being saved as strings in the definition after the flow exportation, so we should parse it at the definition loading