### PR TITLE
[FLOWS-35] - Fix: Paste action changing mouse state

### DIFF
--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -395,7 +395,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   }
 
   private handleCanvasKeyDown(event: any) {
-    if (event.key === 'v') {
+    if (event.key === 'v' && !(event.ctrlKey || event.metaKey)) {
       if (this.props.mouseState === MouseState.SELECT) {
         this.props.onMouseStateChange(MouseState.DRAG);
       } else {


### PR DESCRIPTION
- On paste the CTRL/META keys were not being checked, making the mouse state change when CTRL+V was pressed