### PR TITLE
[FLOWS-36] - Fix: parse sticky position on definition load

### DIFF
--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -334,6 +334,13 @@ export const loadFlowDefinition = (details: FlowDetails, assetStore: AssetStore)
     }
   }
 
+  for (const stickyUuid of Object.keys(definition._ui.stickies)) {
+    definition._ui.stickies[stickyUuid].position = {
+      left: parseFloat(definition._ui.stickies[stickyUuid].position.left as any),
+      top: parseFloat(definition._ui.stickies[stickyUuid].position.top as any)
+    };
+  }
+
   // add assets we found in our flow to our asset store
   const components = getFlowComponents(definition);
   mergeAssetMaps(assetStore.fields.items, components.fields);


### PR DESCRIPTION
- After a flow export, float positions are saved as string, we should parse them on definition load for stickies too