### PR TITLE
[FLOWS-102] - Feat: Use @material-symbols/font-400 to reduce font load size and time

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "private": false,
   "dependencies": {
+    "@material-symbols/font-400": "0.13.2",
     "@weni/unnnic-system": "1.16.51",
-    "material-symbols": "0.13.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "sms-length": "0.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import 'static/fonts/floweditor/style.css';
 
 import '@weni/unnnic-system/dist/unnnic.css';
 
-import 'material-symbols';
+import '@material-symbols/font-400';
 
 import FlowEditor from 'components';
 import React from 'react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,6 +1350,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@material-symbols/font-400@0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@material-symbols/font-400/-/font-400-0.13.2.tgz#a942b02f3586264efb7be8bd859245ea302f0787"
+  integrity sha512-vcsxFg83xP4UjglcG4mWwsZJ/obLYcTzdwAmhYDtPgSIjbmF8p7+wiw/79TDJBxdvnfDnnc0wFsqylTr1La7OA==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -8653,11 +8658,6 @@ matcher@^1.0.0:
   integrity sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==
   dependencies:
     escape-string-regexp "^1.0.4"
-
-material-symbols@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/material-symbols/-/material-symbols-0.13.0.tgz#02fe8eaf8d504a7504a19e6cb36e67a808bcb805"
-  integrity sha512-NZZBJjY3NqIlGWYns+YkkTdBUAXZQEjaIRH8T0x0Ycnt+J4Q90IOuLTVgQWjGVYxG87CgOEB73BSAlSoGFh4fA==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
- [@material-symbols/font-400](https://www.npmjs.com/package/@material-symbols/font-400) has a reduced size in comparison with [material-symbols](https://www.npmjs.com/package/material-symbols), improving load size and time.