### PR TITLE
Fix: Include smart router in case localization condition

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -173,7 +173,7 @@ export const getLocalizations = (
   const localizations: LocalizedObject[] = [];
 
   // Account for localized cases
-  if (node.router && node.router.type === RouterTypes.switch) {
+  if (node.router && [RouterTypes.switch, RouterTypes.smart].includes(node.router.type)) {
     const router = node.router as SwitchRouter;
 
     router.cases.forEach(kase =>


### PR DESCRIPTION
- Smart routers are now able to display localized cases after the node is saved