### PR TITLE
Refactor: Replace UnnnicModalNext usage with UnnnicModal

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "dependencies": {
     "@material-symbols/font-400": "0.13.2",
-    "@weni/unnnic-system": "1.24.5",
+    "@weni/unnnic-system": "1.24.8",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "sms-length": "0.1.2",

--- a/src/components/flow/Flow.tsx
+++ b/src/components/flow/Flow.tsx
@@ -49,23 +49,11 @@ import { PopTabType } from 'config/interfaces';
 import styles from './Flow.module.scss';
 import { applyVueInReact } from 'vuereact-combined';
 // @ts-ignore
-import { unnnicModalNext, unnnicButtonNext } from '@weni/unnnic-system';
+import { unnnicModal, unnnicButton } from '@weni/unnnic-system';
 import { WeniLoveIcon } from './WeniLoveIcon';
 import i18n from '../../config/i18n';
 
-const UnnnicButton = applyVueInReact(unnnicButtonNext, {
-  vue: {
-    componentWrap: 'div',
-    slotWrap: 'div',
-    componentWrapAttrs: {
-      style: {
-        all: ''
-      }
-    }
-  }
-});
-
-const UnnnicModalNext = applyVueInReact(unnnicModalNext, {
+const UnnnicModal = applyVueInReact(unnnicModal, {
   vue: {
     componentWrap: 'div',
     slotWrap: 'div',
@@ -74,6 +62,29 @@ const UnnnicModalNext = applyVueInReact(unnnicModalNext, {
         all: '',
         position: 'relative',
         zIndex: 10e2
+      }
+    }
+  },
+  react: {
+    componentWrap: 'div',
+    slotWrap: 'div',
+    componentWrapAttrs: {
+      __use_react_component_wrap: '',
+      style: {
+        all: ''
+      }
+    }
+  }
+});
+
+const UnnnicButton = applyVueInReact(unnnicButton, {
+  vue: {
+    componentWrap: 'div',
+    slotWrap: 'div',
+    componentWrapAttrs: {
+      style: {
+        display: 'flex',
+        flex: 1
       }
     }
   }
@@ -441,7 +452,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
     }
 
     ReactDOM.render(
-      <UnnnicModalNext className={styles.new_updates}>
+      <UnnnicModal className={styles.new_updates} closeIcon={false}>
         <div className={styles.content}>
           <WeniLoveIcon />
           <span className={styles.title}>{i18n.t('new_updates.title', 'News in the area!')}</span>
@@ -487,7 +498,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
 
         <div className={styles.buttons}>
           <UnnnicButton
-            type="ghost"
+            type="tertiary"
             text={i18n.t('new_updates.buttons.first', 'Close')}
             onClick={() => {
               ReactDOM.unmountComponentAtNode(newUpdatesModalEl);
@@ -503,7 +514,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
             }}
           />
         </div>
-      </UnnnicModalNext>,
+      </UnnnicModal>,
       newUpdatesModalEl
     );
   }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,3 @@
-import ReactDOM from 'react-dom';
 import { fakePropType } from 'config/ConfigProvider';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -18,25 +17,11 @@ import i18n from 'config/i18n';
 import { applyVueInReact } from 'vuereact-combined';
 import styles from './Sidebar.module.scss';
 // @ts-ignore
-import { unnnicModalNext, unnnicToolTip } from '@weni/unnnic-system';
+import { unnnicToolTip } from '@weni/unnnic-system';
 import GuidingSteps from 'components/guidingsteps/GuidingSteps';
 import { MouseState } from 'store/editor';
 
 const UnnnicTooltip = applyVueInReact(unnnicToolTip);
-
-const UnnnicModalNext = applyVueInReact(unnnicModalNext, {
-  vue: {
-    componentWrap: 'div',
-    slotWrap: 'div',
-    componentWrapAttrs: {
-      style: {
-        all: '',
-        position: 'relative',
-        zIndex: 10e2
-      }
-    }
-  }
-});
 
 export interface SidebarStoreProps {
   onCopyClick: () => void;
@@ -64,49 +49,6 @@ export class Sidebar extends React.PureComponent<SidebarStoreProps, {}> {
     const emptyNode = createEmptyNode(null, null, 1, this.context.config.flowType);
 
     this.props.onCreateNode(emptyNode);
-  }
-
-  public componentDidMount(): void {
-    if (Object.keys(this.props.nodes).length === 0) {
-      // this.showGetStartedModal();
-    }
-  }
-
-  private showGetStartedModal(): void {
-    let getStartedModalEl: HTMLDivElement = document.querySelector('#get-started-modal');
-
-    if (!getStartedModalEl) {
-      getStartedModalEl = document.createElement('div');
-      getStartedModalEl.setAttribute('id', 'get-started-modal');
-      document.body.appendChild(getStartedModalEl);
-    }
-
-    if (getStartedModalEl.hasChildNodes()) {
-      return;
-    }
-
-    ReactDOM.render(
-      <UnnnicModalNext
-        type="alert"
-        scheme="feedback-yellow"
-        title={i18n.t('empty_flow_message_title')}
-        description={i18n.t('empty_flow_message_description')}
-        actionPrimaryLabel={i18n.t('buttons.create_message')}
-        actionPrimaryButtonType="secondary"
-        on={{
-          'click-action-primary': () => {
-            this.createSendMessageNode();
-
-            ReactDOM.unmountComponentAtNode(getStartedModalEl);
-          },
-          'click-action-secondary': () => {
-            ReactDOM.unmountComponentAtNode(getStartedModalEl);
-          }
-        }}
-        actionSecondaryLabel={i18n.t('buttons.later')}
-      />,
-      getStartedModalEl
-    );
   }
 
   private getCopyTooltip(): string {

--- a/src/components/titlebar/TitleBar.module.scss
+++ b/src/components/titlebar/TitleBar.module.scss
@@ -76,3 +76,19 @@
     color: $unnnic-color-neutral-dark;
   }
 }
+
+
+.removal_modal {
+  div[class="unnnic-modal-container-background-body-description-container"] {
+    padding-bottom: unset;
+  }
+}
+
+.removal_buttons {
+  display: flex;
+  gap: $unnnic-spacing-lg;
+
+  button {
+    flex: 1;
+  }
+}

--- a/src/components/titlebar/TitleBar.test.tsx
+++ b/src/components/titlebar/TitleBar.test.tsx
@@ -1,11 +1,10 @@
 import TitleBar, {
-  confirmRemovalSpecId,
   moveIconSpecId,
   removeIconSpecId,
   TitleBarProps
 } from 'components/titlebar/TitleBar';
 import React from 'react';
-import { fireEvent, render } from 'test/utils';
+import { act, fireEvent, render } from 'test/utils';
 
 const baseProps: TitleBarProps = {
   title: 'Send Message',
@@ -53,7 +52,7 @@ describe(TitleBar.name, () => {
     });
 
     describe('confirmation', () => {
-      it('should render confirmation markup and call onRemoval prop', () => {
+      it('should render confirmation markup and call onRemoval prop', async () => {
         const handleRemoveClicked = jest.fn();
         const { baseElement, getByTestId, getByText } = render(
           <TitleBar
@@ -66,7 +65,9 @@ describe(TitleBar.name, () => {
 
         expect(baseElement).toMatchSnapshot();
 
-        fireEvent.mouseUp(getByTestId(removeIconSpecId));
+        await act(async () => {
+          fireEvent.mouseUp(getByTestId(removeIconSpecId));
+        });
         fireEvent.click(getByText('Confirm'));
         expect(handleRemoveClicked).toHaveBeenCalledTimes(1);
       });

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -9,7 +9,7 @@ import i18n from 'config/i18n';
 import { applyVueInReact } from 'vuereact-combined';
 
 // @ts-ignore
-import { unnnicIcon, unnnicModalNext } from '@weni/unnnic-system';
+import { unnnicIcon, unnnicModal, unnnicButton } from '@weni/unnnic-system';
 
 export interface TitleBarProps {
   title: string;
@@ -37,7 +37,7 @@ export const confirmRemovalSpecId = 'confirm-removal';
  */
 
 const UnnnicIcon = applyVueInReact(unnnicIcon);
-const UnnnicModalNext = applyVueInReact(unnnicModalNext, {
+const UnnnicModal = applyVueInReact(unnnicModal, {
   vue: {
     componentWrap: 'div',
     slotWrap: 'div',
@@ -46,6 +46,29 @@ const UnnnicModalNext = applyVueInReact(unnnicModalNext, {
         all: '',
         position: 'relative',
         zIndex: 10e2
+      }
+    }
+  },
+  react: {
+    componentWrap: 'div',
+    slotWrap: 'div',
+    componentWrapAttrs: {
+      __use_react_component_wrap: '',
+      style: {
+        all: ''
+      }
+    }
+  }
+});
+
+const UnnnicButton = applyVueInReact(unnnicButton, {
+  vue: {
+    componentWrap: 'div',
+    slotWrap: 'div',
+    componentWrapAttrs: {
+      style: {
+        display: 'flex',
+        flex: 1
       }
     }
   }
@@ -81,18 +104,14 @@ export default class TitleBar extends React.Component<TitleBarProps> {
     const { onRemoval } = this.props;
 
     ReactDOM.render(
-      <UnnnicModalNext
+      <UnnnicModal
+        className={styles.removal_modal}
         data-testid={confirmRemovalSpecId}
-        type="alert"
-        icon="alert-circle-1"
+        modalIcon="alert-circle-1"
         scheme="feedback-yellow"
-        title={i18n.t('removal_confirmation', 'Do you want to delete the card?')}
-        actionPrimaryLabel={i18n.t('buttons.confirm', 'Confirm')}
-        actionSecondaryLabel={i18n.t('buttons.cancel', 'Cancel')}
-        actionPrimaryButtonType="primary"
-        showCloseButton
+        text={i18n.t('removal_confirmation', 'Do you want to delete the card?')}
         $slots={{
-          description: (
+          message: (
             <>
               {i18n.t(
                 'removal_confirmation_description',
@@ -108,14 +127,27 @@ export default class TitleBar extends React.Component<TitleBarProps> {
               )}{' '}
               <b>delete</b> {i18n.t('or', 'or')} <b>backspace</b>.
             </>
+          ),
+          options: (
+            <div className={styles.removal_buttons}>
+              <UnnnicButton
+                text={i18n.t('buttons.cancel', 'Cancel')}
+                type="tertiary"
+                onClick={() => ReactDOM.unmountComponentAtNode(div)}
+              />
+              <UnnnicButton
+                text={i18n.t('buttons.confirm', 'Confirm')}
+                type="attention"
+                onClick={() => {
+                  onRemoval();
+                  ReactDOM.unmountComponentAtNode(div);
+                }}
+              />
+            </div>
           )
         }}
         on={{
           close() {
-            ReactDOM.unmountComponentAtNode(div);
-          },
-          'click-action-primary': () => {
-            onRemoval();
             ReactDOM.unmountComponentAtNode(div);
           }
         }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,11 +2246,12 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@weni/unnnic-system@1.24.5":
-  version "1.24.5"
-  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-1.24.5.tgz#7694aab5140c3c1596b2e74f039ccf160fe38fe0"
-  integrity sha512-G+FLDs0szhMl5Dv6KC45lvfa+wreu0k4BN/I1QO4LcBoTObhEyjARIijWnoql4AmuUcximHg4PgNhUMFquwfKw==
+"@weni/unnnic-system@1.24.8":
+  version "1.24.8"
+  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-1.24.8.tgz#02e8a37605e678ff2d390b724c3476da7b5ec07e"
+  integrity sha512-161a3WYJCf5Y4Kkd8YlvKsYnzky5fXEl5zznE6jLd+zoulf9iBO26CrJjS2upTSbWOF0Pb7/DqEIR6WEDDRrIw==
   dependencies:
+    axios "^1.5.1"
     core-js "^3.6.5"
     lodash "^4.17.21"
     mime-types "^2.1.35"
@@ -2845,6 +2846,15 @@ axios@0.21.2:
   integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^1.5.1:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^2.0.2:
   version "2.1.2"
@@ -5860,6 +5870,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -5900,6 +5915,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -10795,6 +10819,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [X] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
UnnnicModalNext component is now deprecated, and its usage should be replaced with UnnnicModal

### Summary of Changes
Replaced UnnnicModalNext usage with UnnnicModal, and removed unused modal from code base

