### PR TITLE
refactor: remove unnnic button next usage

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import { applyVueInReact } from 'vuereact-combined';
 
 // @ts-ignore
-import { unnnicButtonNext } from '@weni/unnnic-system';
+import { unnnicButton } from '@weni/unnnic-system';
 
 export enum ButtonTypes {
   primary = 'primary',
   secondary = 'secondary',
-  tertiary = 'terciary',
+  tertiary = 'tertiary',
   ghost = 'ghost'
 }
 export interface ButtonProps {
@@ -23,7 +23,7 @@ export interface ButtonProps {
   onRef?: (ele: any) => void;
 }
 
-const UnnnicButton = applyVueInReact(unnnicButtonNext, {
+const UnnnicButton = applyVueInReact(unnnicButton, {
   vue: {
     componentWrap: 'div',
     slotWrap: 'div',

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -8,8 +8,7 @@ import { unnnicButton } from '@weni/unnnic-system';
 export enum ButtonTypes {
   primary = 'primary',
   secondary = 'secondary',
-  tertiary = 'tertiary',
-  ghost = 'ghost'
+  tertiary = 'tertiary'
 }
 export interface ButtonProps {
   name: string;

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -7,17 +7,17 @@ exports[`Button render should render self, children with base props 1`] = `
       data-use-vue-component-wrap=""
     >
       <button
-        class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+        class="unnnic-button unnnic-button--size-large unnnic-button--primary"
         data-passed-props="[object Object]"
-        data-v-1eef067c=""
+        data-v-2d9f2cbf=""
         style="margin-left: 0px; margin-top: 0px;"
       >
         <!---->
         <!---->
         <!---->
         <span
-          class="unnnic-button-next__label"
-          data-v-1eef067c=""
+          class="unnnic-button__label"
+          data-v-2d9f2cbf=""
         >
            Save 
         </span>

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Button render should render self, children with base props 1`] = `
       <button
         class="unnnic-button unnnic-button--size-large unnnic-button--primary"
         data-passed-props="[object Object]"
-        data-v-2d9f2cbf=""
+        data-v-3b3aa28c=""
         style="margin-left: 0px; margin-top: 0px;"
       >
         <!---->
@@ -17,7 +17,7 @@ exports[`Button render should render self, children with base props 1`] = `
         <!---->
         <span
           class="unnnic-button__label"
-          data-v-2d9f2cbf=""
+          data-v-3b3aa28c=""
         >
            Save 
         </span>

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -138,7 +138,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
     };
 
     if (buttons.secondary) {
-      rightButtons.push(<Button key={0} type={ButtonTypes.ghost} {...buttons.secondary} />);
+      rightButtons.push(<Button key={0} type={ButtonTypes.tertiary} {...buttons.secondary} />);
     }
 
     if (buttons.primary) {
@@ -165,7 +165,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
 
     // Our left most button if we have one
     if (buttons.tertiary) {
-      leftButtons.push(<Button key={0} type={ButtonTypes.ghost} {...buttons.tertiary} />);
+      leftButtons.push(<Button key={0} type={ButtonTypes.tertiary} {...buttons.tertiary} />);
     }
 
     return {

--- a/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Dialog should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -63,7 +63,7 @@ exports[`Dialog should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Other 
                   </span>
@@ -80,7 +80,7 @@ exports[`Dialog should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -88,7 +88,7 @@ exports[`Dialog should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -101,7 +101,7 @@ exports[`Dialog should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -109,7 +109,7 @@ exports[`Dialog should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>

--- a/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -53,17 +53,17 @@ exports[`Dialog should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Other 
                   </span>
@@ -78,17 +78,17 @@ exports[`Dialog should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -99,17 +99,17 @@ exports[`Dialog should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/actions/addlabels/__snapshots__/AddLabelsForm.test.tsx.snap
+++ b/src/components/flow/actions/addlabels/__snapshots__/AddLabelsForm.test.tsx.snap
@@ -503,7 +503,7 @@ exports[`AddLabelsForm render allows expressions 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -511,7 +511,7 @@ exports[`AddLabelsForm render allows expressions 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -524,7 +524,7 @@ exports[`AddLabelsForm render allows expressions 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -532,7 +532,7 @@ exports[`AddLabelsForm render allows expressions 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -1065,7 +1065,7 @@ exports[`AddLabelsForm render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1073,7 +1073,7 @@ exports[`AddLabelsForm render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1086,7 +1086,7 @@ exports[`AddLabelsForm render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1094,7 +1094,7 @@ exports[`AddLabelsForm render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/actions/addlabels/__snapshots__/AddLabelsForm.test.tsx.snap
+++ b/src/components/flow/actions/addlabels/__snapshots__/AddLabelsForm.test.tsx.snap
@@ -501,17 +501,17 @@ exports[`AddLabelsForm render allows expressions 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -522,17 +522,17 @@ exports[`AddLabelsForm render allows expressions 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -1063,17 +1063,17 @@ exports[`AddLabelsForm render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1084,17 +1084,17 @@ exports[`AddLabelsForm render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/actions/addurn/__snapshots__/AddURNForm.test.tsx.snap
+++ b/src/components/flow/actions/addurn/__snapshots__/AddURNForm.test.tsx.snap
@@ -687,17 +687,17 @@ exports[`AddURNForm renders 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -708,17 +708,17 @@ exports[`AddURNForm renders 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/actions/addurn/__snapshots__/AddURNForm.test.tsx.snap
+++ b/src/components/flow/actions/addurn/__snapshots__/AddURNForm.test.tsx.snap
@@ -689,7 +689,7 @@ exports[`AddURNForm renders 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -697,7 +697,7 @@ exports[`AddURNForm renders 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -710,7 +710,7 @@ exports[`AddURNForm renders 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -718,7 +718,7 @@ exports[`AddURNForm renders 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/actions/localization/__snapshots__/KeyLocalizationForm.test.tsx.snap
+++ b/src/components/flow/actions/localization/__snapshots__/KeyLocalizationForm.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`KeyLocalizationForm removes translations 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -163,7 +163,7 @@ exports[`KeyLocalizationForm removes translations 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -176,7 +176,7 @@ exports[`KeyLocalizationForm removes translations 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -184,7 +184,7 @@ exports[`KeyLocalizationForm removes translations 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -352,7 +352,7 @@ exports[`KeyLocalizationForm renders send email 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -360,7 +360,7 @@ exports[`KeyLocalizationForm renders send email 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -373,7 +373,7 @@ exports[`KeyLocalizationForm renders send email 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -381,7 +381,7 @@ exports[`KeyLocalizationForm renders send email 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/actions/localization/__snapshots__/KeyLocalizationForm.test.tsx.snap
+++ b/src/components/flow/actions/localization/__snapshots__/KeyLocalizationForm.test.tsx.snap
@@ -153,17 +153,17 @@ exports[`KeyLocalizationForm removes translations 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -174,17 +174,17 @@ exports[`KeyLocalizationForm removes translations 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -350,17 +350,17 @@ exports[`KeyLocalizationForm renders send email 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -371,17 +371,17 @@ exports[`KeyLocalizationForm renders send email 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.tsx.snap
+++ b/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.tsx.snap
@@ -771,17 +771,17 @@ exports[`StartSessionForm render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -792,17 +792,17 @@ exports[`StartSessionForm render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -1582,17 +1582,17 @@ exports[`StartSessionForm render should render contact query 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1603,17 +1603,17 @@ exports[`StartSessionForm render should render contact query 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -2213,17 +2213,17 @@ exports[`StartSessionForm render should render create new contacts 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -2234,17 +2234,17 @@ exports[`StartSessionForm render should render create new contacts 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -3024,17 +3024,17 @@ exports[`StartSessionForm render should warn about invalid fields in contact que
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -3045,17 +3045,17 @@ exports[`StartSessionForm render should warn about invalid fields in contact que
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.tsx.snap
+++ b/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.tsx.snap
@@ -773,7 +773,7 @@ exports[`StartSessionForm render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -781,7 +781,7 @@ exports[`StartSessionForm render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -794,7 +794,7 @@ exports[`StartSessionForm render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -802,7 +802,7 @@ exports[`StartSessionForm render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -1584,7 +1584,7 @@ exports[`StartSessionForm render should render contact query 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1592,7 +1592,7 @@ exports[`StartSessionForm render should render contact query 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1605,7 +1605,7 @@ exports[`StartSessionForm render should render contact query 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1613,7 +1613,7 @@ exports[`StartSessionForm render should render contact query 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -2215,7 +2215,7 @@ exports[`StartSessionForm render should render create new contacts 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -2223,7 +2223,7 @@ exports[`StartSessionForm render should render create new contacts 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -2236,7 +2236,7 @@ exports[`StartSessionForm render should render create new contacts 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -2244,7 +2244,7 @@ exports[`StartSessionForm render should render create new contacts 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -3026,7 +3026,7 @@ exports[`StartSessionForm render should warn about invalid fields in contact que
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -3034,7 +3034,7 @@ exports[`StartSessionForm render should warn about invalid fields in contact que
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -3047,7 +3047,7 @@ exports[`StartSessionForm render should warn about invalid fields in contact que
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -3055,7 +3055,7 @@ exports[`StartSessionForm render should warn about invalid fields in contact que
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/actions/updatecontact/__snapshots__/UpdateContactForm.test.tsx.snap
+++ b/src/components/flow/actions/updatecontact/__snapshots__/UpdateContactForm.test.tsx.snap
@@ -591,7 +591,7 @@ exports[`UpdateContactForm should render channel 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -599,7 +599,7 @@ exports[`UpdateContactForm should render channel 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -612,7 +612,7 @@ exports[`UpdateContactForm should render channel 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -620,7 +620,7 @@ exports[`UpdateContactForm should render channel 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -1193,7 +1193,7 @@ exports[`UpdateContactForm should render field 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1201,7 +1201,7 @@ exports[`UpdateContactForm should render field 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1214,7 +1214,7 @@ exports[`UpdateContactForm should render field 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1222,7 +1222,7 @@ exports[`UpdateContactForm should render field 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -1831,7 +1831,7 @@ exports[`UpdateContactForm should render language 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1839,7 +1839,7 @@ exports[`UpdateContactForm should render language 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1852,7 +1852,7 @@ exports[`UpdateContactForm should render language 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1860,7 +1860,7 @@ exports[`UpdateContactForm should render language 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -2433,7 +2433,7 @@ exports[`UpdateContactForm should render name 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -2441,7 +2441,7 @@ exports[`UpdateContactForm should render name 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -2454,7 +2454,7 @@ exports[`UpdateContactForm should render name 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -2462,7 +2462,7 @@ exports[`UpdateContactForm should render name 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/actions/updatecontact/__snapshots__/UpdateContactForm.test.tsx.snap
+++ b/src/components/flow/actions/updatecontact/__snapshots__/UpdateContactForm.test.tsx.snap
@@ -589,17 +589,17 @@ exports[`UpdateContactForm should render channel 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -610,17 +610,17 @@ exports[`UpdateContactForm should render channel 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -1191,17 +1191,17 @@ exports[`UpdateContactForm should render field 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1212,17 +1212,17 @@ exports[`UpdateContactForm should render field 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -1829,17 +1829,17 @@ exports[`UpdateContactForm should render language 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1850,17 +1850,17 @@ exports[`UpdateContactForm should render language 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -2431,17 +2431,17 @@ exports[`UpdateContactForm should render name 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -2452,17 +2452,17 @@ exports[`UpdateContactForm should render name 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/dial/__snapshots__/DialRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/dial/__snapshots__/DialRouterForm.test.tsx.snap
@@ -483,7 +483,7 @@ exports[`DialRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -491,7 +491,7 @@ exports[`DialRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -504,7 +504,7 @@ exports[`DialRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -512,7 +512,7 @@ exports[`DialRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/dial/__snapshots__/DialRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/dial/__snapshots__/DialRouterForm.test.tsx.snap
@@ -481,17 +481,17 @@ exports[`DialRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -502,17 +502,17 @@ exports[`DialRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/externalservice/__snapshots__/ExternalServiceRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/externalservice/__snapshots__/ExternalServiceRouterForm.test.tsx.snap
@@ -615,17 +615,17 @@ exports[`ExternalServiceRouterForm ChatGPT render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -636,17 +636,17 @@ exports[`ExternalServiceRouterForm ChatGPT render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -1652,17 +1652,17 @@ exports[`ExternalServiceRouterForm ChatGPT updates should save changes 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1673,17 +1673,17 @@ exports[`ExternalServiceRouterForm ChatGPT updates should save changes 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -2935,17 +2935,17 @@ exports[`ExternalServiceRouterForm Omie render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -2956,17 +2956,17 @@ exports[`ExternalServiceRouterForm Omie render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -4411,17 +4411,17 @@ exports[`ExternalServiceRouterForm Omie updates should save changes 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -4432,17 +4432,17 @@ exports[`ExternalServiceRouterForm Omie updates should save changes 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/externalservice/__snapshots__/ExternalServiceRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/externalservice/__snapshots__/ExternalServiceRouterForm.test.tsx.snap
@@ -617,7 +617,7 @@ exports[`ExternalServiceRouterForm ChatGPT render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -625,7 +625,7 @@ exports[`ExternalServiceRouterForm ChatGPT render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -638,7 +638,7 @@ exports[`ExternalServiceRouterForm ChatGPT render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -646,7 +646,7 @@ exports[`ExternalServiceRouterForm ChatGPT render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -1654,7 +1654,7 @@ exports[`ExternalServiceRouterForm ChatGPT updates should save changes 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1662,7 +1662,7 @@ exports[`ExternalServiceRouterForm ChatGPT updates should save changes 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1675,7 +1675,7 @@ exports[`ExternalServiceRouterForm ChatGPT updates should save changes 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1683,7 +1683,7 @@ exports[`ExternalServiceRouterForm ChatGPT updates should save changes 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -2937,7 +2937,7 @@ exports[`ExternalServiceRouterForm Omie render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -2945,7 +2945,7 @@ exports[`ExternalServiceRouterForm Omie render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -2958,7 +2958,7 @@ exports[`ExternalServiceRouterForm Omie render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -2966,7 +2966,7 @@ exports[`ExternalServiceRouterForm Omie render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -4413,7 +4413,7 @@ exports[`ExternalServiceRouterForm Omie updates should save changes 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -4421,7 +4421,7 @@ exports[`ExternalServiceRouterForm Omie updates should save changes 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -4434,7 +4434,7 @@ exports[`ExternalServiceRouterForm Omie updates should save changes 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -4442,7 +4442,7 @@ exports[`ExternalServiceRouterForm Omie updates should save changes 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/random/__snapshots__/RandomRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/random/__snapshots__/RandomRouterForm.test.tsx.snap
@@ -998,17 +998,17 @@ exports[`RandomRouterForm should initialize existing random 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1019,17 +1019,17 @@ exports[`RandomRouterForm should initialize existing random 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -1764,17 +1764,17 @@ exports[`RandomRouterForm should remove exits when shrinking 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1785,17 +1785,17 @@ exports[`RandomRouterForm should remove exits when shrinking 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/random/__snapshots__/RandomRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/random/__snapshots__/RandomRouterForm.test.tsx.snap
@@ -1000,7 +1000,7 @@ exports[`RandomRouterForm should initialize existing random 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1008,7 +1008,7 @@ exports[`RandomRouterForm should initialize existing random 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1021,7 +1021,7 @@ exports[`RandomRouterForm should initialize existing random 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1029,7 +1029,7 @@ exports[`RandomRouterForm should initialize existing random 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -1766,7 +1766,7 @@ exports[`RandomRouterForm should remove exits when shrinking 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1774,7 +1774,7 @@ exports[`RandomRouterForm should remove exits when shrinking 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1787,7 +1787,7 @@ exports[`RandomRouterForm should remove exits when shrinking 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1795,7 +1795,7 @@ exports[`RandomRouterForm should remove exits when shrinking 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
@@ -1107,17 +1107,17 @@ exports[`ResultRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1128,17 +1128,17 @@ exports[`ResultRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -2571,17 +2571,17 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -2592,17 +2592,17 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
@@ -1109,7 +1109,7 @@ exports[`ResultRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1117,7 +1117,7 @@ exports[`ResultRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1130,7 +1130,7 @@ exports[`ResultRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1138,7 +1138,7 @@ exports[`ResultRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -2573,7 +2573,7 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -2581,7 +2581,7 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -2594,7 +2594,7 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -2602,7 +2602,7 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/scheme/__snapshots__/SchemeRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/scheme/__snapshots__/SchemeRouterForm.test.tsx.snap
@@ -1345,17 +1345,17 @@ exports[`SchemeRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1366,17 +1366,17 @@ exports[`SchemeRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/scheme/__snapshots__/SchemeRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/scheme/__snapshots__/SchemeRouterForm.test.tsx.snap
@@ -1347,7 +1347,7 @@ exports[`SchemeRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1355,7 +1355,7 @@ exports[`SchemeRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1368,7 +1368,7 @@ exports[`SchemeRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1376,7 +1376,7 @@ exports[`SchemeRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
@@ -594,17 +594,17 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -615,17 +615,17 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -1098,17 +1098,17 @@ exports[`SubflowRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1119,17 +1119,17 @@ exports[`SubflowRouterForm should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
@@ -596,7 +596,7 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -604,7 +604,7 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -617,7 +617,7 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -625,7 +625,7 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -1100,7 +1100,7 @@ exports[`SubflowRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1108,7 +1108,7 @@ exports[`SubflowRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1121,7 +1121,7 @@ exports[`SubflowRouterForm should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1129,7 +1129,7 @@ exports[`SubflowRouterForm should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/ticket/__snapshots__/TicketRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/ticket/__snapshots__/TicketRouterForm.test.tsx.snap
@@ -665,17 +665,17 @@ exports[`TicketRouterForm render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -686,17 +686,17 @@ exports[`TicketRouterForm render should render 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>
@@ -1377,17 +1377,17 @@ exports[`TicketRouterForm updates should save changes 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1398,17 +1398,17 @@ exports[`TicketRouterForm updates should save changes 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/ticket/__snapshots__/TicketRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/ticket/__snapshots__/TicketRouterForm.test.tsx.snap
@@ -667,7 +667,7 @@ exports[`TicketRouterForm render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -675,7 +675,7 @@ exports[`TicketRouterForm render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -688,7 +688,7 @@ exports[`TicketRouterForm render should render 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -696,7 +696,7 @@ exports[`TicketRouterForm render should render 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>
@@ -1379,7 +1379,7 @@ exports[`TicketRouterForm updates should save changes 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1387,7 +1387,7 @@ exports[`TicketRouterForm updates should save changes 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1400,7 +1400,7 @@ exports[`TicketRouterForm updates should save changes 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1408,7 +1408,7 @@ exports[`TicketRouterForm updates should save changes 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Ok 
                   </span>

--- a/src/components/flow/routers/wait/__snapshots__/WaitRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/wait/__snapshots__/WaitRouterForm.test.tsx.snap
@@ -460,7 +460,7 @@ exports[`WaitRouterForm should render a normal wait 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -468,7 +468,7 @@ exports[`WaitRouterForm should render a normal wait 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -481,7 +481,7 @@ exports[`WaitRouterForm should render a normal wait 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -489,7 +489,7 @@ exports[`WaitRouterForm should render a normal wait 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -941,7 +941,7 @@ exports[`WaitRouterForm should render wait for audio with previous name 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -949,7 +949,7 @@ exports[`WaitRouterForm should render wait for audio with previous name 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -962,7 +962,7 @@ exports[`WaitRouterForm should render wait for audio with previous name 1`] = `
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -970,7 +970,7 @@ exports[`WaitRouterForm should render wait for audio with previous name 1`] = `
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/wait/__snapshots__/WaitRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/wait/__snapshots__/WaitRouterForm.test.tsx.snap
@@ -458,17 +458,17 @@ exports[`WaitRouterForm should render a normal wait 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -479,17 +479,17 @@ exports[`WaitRouterForm should render a normal wait 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -939,17 +939,17 @@ exports[`WaitRouterForm should render wait for audio with previous name 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -960,17 +960,17 @@ exports[`WaitRouterForm should render wait for audio with previous name 1`] = `
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/whatsapp/sendproduct/__snapshots__/SendWhatsAppProductRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/whatsapp/sendproduct/__snapshots__/SendWhatsAppProductRouterForm.test.tsx.snap
@@ -682,7 +682,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should render 1`
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -690,7 +690,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should render 1`
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -707,7 +707,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should render 1`
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -715,7 +715,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should render 1`
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -1413,7 +1413,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -1421,7 +1421,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -1438,7 +1438,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -1446,7 +1446,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -2355,7 +2355,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -2363,7 +2363,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -2380,7 +2380,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -2388,7 +2388,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -3159,7 +3159,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -3167,7 +3167,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -3184,7 +3184,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -3192,7 +3192,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -4219,7 +4219,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -4227,7 +4227,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -4244,7 +4244,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -4252,7 +4252,7 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -5188,7 +5188,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -5196,7 +5196,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -5213,7 +5213,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -5221,7 +5221,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -5919,7 +5919,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -5927,7 +5927,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -5944,7 +5944,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -5952,7 +5952,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -6815,7 +6815,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should render 1`] =
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -6823,7 +6823,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should render 1`] =
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -6840,7 +6840,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should render 1`] =
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -6848,7 +6848,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should render 1`] =
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -7711,7 +7711,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -7719,7 +7719,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -7736,7 +7736,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -7744,7 +7744,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -8855,7 +8855,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -8863,7 +8863,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -8880,7 +8880,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -8888,7 +8888,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -9784,7 +9784,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -9792,7 +9792,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -9809,7 +9809,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -9817,7 +9817,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -10753,7 +10753,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -10761,7 +10761,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -10778,7 +10778,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -10786,7 +10786,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>
@@ -11897,7 +11897,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
@@ -11905,7 +11905,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Cancel 
                   </span>
@@ -11922,7 +11922,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 <button
                   class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-2d9f2cbf=""
+                  data-v-3b3aa28c=""
                   style="margin-top: 0px;"
                 >
                   <!---->
@@ -11930,7 +11930,7 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                   <!---->
                   <span
                     class="unnnic-button__label"
-                    data-v-2d9f2cbf=""
+                    data-v-3b3aa28c=""
                   >
                      Confirm 
                   </span>

--- a/src/components/flow/routers/whatsapp/sendproduct/__snapshots__/SendWhatsAppProductRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/whatsapp/sendproduct/__snapshots__/SendWhatsAppProductRouterForm.test.tsx.snap
@@ -680,17 +680,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should render 1`
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -705,17 +705,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should render 1`
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -1411,17 +1411,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -1436,17 +1436,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -2353,17 +2353,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -2378,17 +2378,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -3157,17 +3157,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -3182,17 +3182,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -4217,17 +4217,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -4242,17 +4242,17 @@ exports[`SendWhatsAppProductRouterForm automatic product search should save an a
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -5186,17 +5186,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -5211,17 +5211,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -5917,17 +5917,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -5942,17 +5942,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should change from 
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -6813,17 +6813,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should render 1`] =
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -6838,17 +6838,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should render 1`] =
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -7709,17 +7709,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -7734,17 +7734,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -8853,17 +8853,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -8878,17 +8878,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -9782,17 +9782,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -9807,17 +9807,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a catal
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -10751,17 +10751,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -10776,17 +10776,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>
@@ -11895,17 +11895,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--ghost unnnic-button-next-scheme--"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--tertiary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-left: 0px; margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Cancel 
                   </span>
@@ -11920,17 +11920,17 @@ exports[`SendWhatsAppProductRouterForm manual product search should save a manua
                 data-use-vue-component-wrap=""
               >
                 <button
-                  class="unnnic-button-next unnnic-button-next--size-large unnnic-button-next--primary unnnic-button-next-scheme--undefined"
+                  class="unnnic-button unnnic-button--size-large unnnic-button--primary"
                   data-passed-props="[object Object]"
-                  data-v-1eef067c=""
+                  data-v-2d9f2cbf=""
                   style="margin-top: 0px;"
                 >
                   <!---->
                   <!---->
                   <!---->
                   <span
-                    class="unnnic-button-next__label"
-                    data-v-1eef067c=""
+                    class="unnnic-button__label"
+                    data-v-2d9f2cbf=""
                   >
                      Confirm 
                   </span>

--- a/src/components/uploadbutton/UploadButton.tsx
+++ b/src/components/uploadbutton/UploadButton.tsx
@@ -67,7 +67,7 @@ export default class UploadButton extends React.Component<UploadButtonProps, Upl
             name={this.props.removeText}
             topSpacing={true}
             onClick={this.handleRemoveUpload}
-            type={ButtonTypes.ghost}
+            type={ButtonTypes.tertiary}
           />
         ) : (
           <Button
@@ -77,7 +77,7 @@ export default class UploadButton extends React.Component<UploadButtonProps, Upl
             onClick={() => {
               this.filePicker.click();
             }}
-            type={ButtonTypes.ghost}
+            type={ButtonTypes.tertiary}
           />
         )}
       </>


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [X] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
UnnnicButtonNext is now deprecated

### Summary of Changes
Now using UnnnicButton in place of UnnnicButtonNext