### PR TITLE
[FLOWS-1331] - Fix: Remove external service empty parameters

### DIFF
--- a/src/components/flow/routers/externalservice/ExternalServiceRouterForm.tsx
+++ b/src/components/flow/routers/externalservice/ExternalServiceRouterForm.tsx
@@ -93,11 +93,10 @@ export default class ExternalServiceRouterForm extends React.Component<
         let valid = true;
         // TODO: Check if it is necessary to validate the param if it is not a string
         if (typeof param.data.value === 'string' || param.data.value instanceof String) {
-          if (
-            !param.valid ||
-            param.data.value.trim().length === 0 ||
-            (param.filter.value == null && param.filters && param.filters.length > 0)
-          ) {
+          const missingFilter =
+            param.filter.value === null && param.filters && param.filters.length > 0;
+
+          if (!param.valid || param.data.value.trim().length === 0 || missingFilter) {
             valid = false;
             hasInvalidParam = true;
           }

--- a/src/components/flow/routers/externalservice/ExternalServiceRouterForm.tsx
+++ b/src/components/flow/routers/externalservice/ExternalServiceRouterForm.tsx
@@ -93,7 +93,11 @@ export default class ExternalServiceRouterForm extends React.Component<
         let valid = true;
         // TODO: Check if it is necessary to validate the param if it is not a string
         if (typeof param.data.value === 'string' || param.data.value instanceof String) {
-          if (!param.valid || param.data.value.trim().length === 0) {
+          if (
+            !param.valid ||
+            param.data.value.trim().length === 0 ||
+            (param.filter.value == null && param.filters && param.filters.length > 0)
+          ) {
             valid = false;
             hasInvalidParam = true;
           }

--- a/src/components/flow/routers/externalservice/ExternalServiceRouterForm.tsx
+++ b/src/components/flow/routers/externalservice/ExternalServiceRouterForm.tsx
@@ -94,7 +94,7 @@ export default class ExternalServiceRouterForm extends React.Component<
         // TODO: Check if it is necessary to validate the param if it is not a string
         if (typeof param.data.value === 'string' || param.data.value instanceof String) {
           const missingFilter =
-            param.filter.value === null && param.filters && param.filters.length > 0;
+            param.filter && param.filter.value == null && param.filters && param.filters.length > 0;
 
           if (!param.valid || param.data.value.trim().length === 0 || missingFilter) {
             valid = false;

--- a/src/components/flow/routers/externalservice/helpers.ts
+++ b/src/components/flow/routers/externalservice/helpers.ts
@@ -90,6 +90,11 @@ export const stateToNode = (
     uuid = originalAction.uuid;
   }
 
+  const validParams = state.params.value.filter(
+    (param: any) =>
+      param.valid === true && param.data.value && param.data.validationFailures.length === 0
+  );
+
   const newAction: CallExternalService = {
     uuid,
     type: Types.call_external_service,
@@ -101,7 +106,7 @@ export const stateToNode = (
       actions: state.externalService.value.actions
     },
     call: state.call.value,
-    params: state.params.value,
+    params: validParams,
     result_name: state.resultName.value
   };
 

--- a/src/components/flow/routers/param/ParamElement.tsx
+++ b/src/components/flow/routers/param/ParamElement.tsx
@@ -199,6 +199,15 @@ export default class ParamElement extends React.Component<ParamElementProps, Par
         </div>
       );
     } else {
+      const filterError =
+        showFilter &&
+        paramFilters &&
+        paramFilters.length > 0 &&
+        !this.state.currentFilter &&
+        this.state.data.value
+          ? [i18n.t('forms.required', 'Required')]
+          : [];
+
       return (
         <>
           <div
@@ -229,6 +238,7 @@ export default class ParamElement extends React.Component<ParamElementProps, Par
                 onChange={this.handleFilterChange}
                 value={this.state.currentFilter}
                 disabled={disableFilter}
+                errors={filterError}
               />
             </div>
           ) : (

--- a/src/components/flow/routers/paramlist/__snapshots__/ParamList.test.tsx.snap
+++ b/src/components/flow/routers/paramlist/__snapshots__/ParamList.test.tsx.snap
@@ -993,7 +993,7 @@ exports[`ParamList Omie render should render list of params 1`] = `
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_options_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   >
                     <div
                       class="option active "
@@ -1079,7 +1079,7 @@ exports[`ParamList Omie render should render list of params 1`] = `
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_expressions_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   />
                 </div>
               </div>
@@ -1391,7 +1391,7 @@ exports[`ParamList Omie render should render list with an empty param 1`] = `
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_options_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   >
                     <div
                       class="option active "
@@ -1477,7 +1477,7 @@ exports[`ParamList Omie render should render list with an empty param 1`] = `
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_expressions_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   />
                 </div>
               </div>
@@ -1789,7 +1789,7 @@ exports[`ParamList Omie updates should remove param and ensure empty param exist
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_options_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   >
                     <div
                       class="option active "
@@ -1875,7 +1875,7 @@ exports[`ParamList Omie updates should remove param and ensure empty param exist
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_expressions_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   />
                 </div>
               </div>
@@ -2139,6 +2139,7 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                       data-passed-props="[object Object]"
                       data-testid="temba_select_input_service_call_param_filter"
                       data-v-48c0c241=""
+                      error="Required"
                       readonly="readonly"
                     >
                       <!---->
@@ -2150,11 +2151,12 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                         v-bind="[object Object]"
                       >
                         <input
-                          class="input-itself input size-sm normal"
+                          class="input-itself input size-sm error"
                           data-passed-props="[object Object]"
                           data-testid="temba_select_input_service_call_param_filter"
                           data-v-400546b3=""
                           data-v-97b44e8c=""
+                          error="Required"
                           iconright="arrow-button-down-1"
                           placeholder="Filter"
                           readonly="readonly"
@@ -2164,7 +2166,7 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                         />
                         <!---->
                         <span
-                          class="unnnic-icon unnnic-icon__size--sm unnnic-icon-scheme--neutral-cloudy icon-right"
+                          class="unnnic-icon unnnic-icon__size--sm unnnic-icon-scheme--feedback-red icon-right"
                           data-v-400546b3=""
                           data-v-4ce83152=""
                         >
@@ -2187,7 +2189,7 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_options_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   >
                     <div
                       class="option active "
@@ -2273,7 +2275,7 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_expressions_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   />
                 </div>
               </div>
@@ -2569,7 +2571,7 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_options_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   >
                     <div
                       class="option active "
@@ -2655,7 +2657,7 @@ exports[`ParamList Omie updates should update params and call the callback 1`] =
                   <div
                     class="options_wrapper"
                     data-testid="temba_select_expressions_service_call_param_filter"
-                    style="margin-top: 0px; width: 0px; display: none;"
+                    style="margin-top: 0px; width: -24px; display: none;"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Description
### Type of Change
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [X] Tests
* * [ ] Other

### Motivation and Context
On external services card, after saving the router the last parameter was an empty one, this was causing an error in mailroom

### Summary of Changes
Removed empty parameters before saving it in the definition, and improved parameter validation to ensure that definition save will only occur after all non-empty parameters are valid
