### PR TITLE
[HT36050] - Fix: Prevent 'Randomly Split' Card from Being Uncopyable.

### DIFF
--- a/src/components/copyAndPasteNodes.ts
+++ b/src/components/copyAndPasteNodes.ts
@@ -193,17 +193,18 @@ export default class {
       }
 
       if (selected.config.node.router) {
-        selected.config.node.router.cases.forEach((caseElement: any) => {
-          caseElement.arguments.forEach((argument: any) => {
-            if (
-              /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/.test(
-                argument,
-              )
-            ) {
-              staticUuids.push(argument);
-            }
+        selected.config.node.router.cases &&
+          selected.config.node.router.cases.forEach((caseElement: any) => {
+            caseElement.arguments.forEach((argument: any) => {
+              if (
+                /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/.test(
+                  argument,
+                )
+              ) {
+                staticUuids.push(argument);
+              }
+            });
           });
-        });
       }
     });
 


### PR DESCRIPTION
## Description
Prevent 'Randomly Split' Card from Being Uncopyable.
### Type of Change

* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The 'Randomly Split' card cannot be copied.

### Summary of Changes
Fix getStaticUuids function when there is a node router without cases.
