### PR TITLE
[FLOWS-2883] Tests: re-add ignored coverage

### DIFF
--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -172,7 +172,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   }
 
   public componentDidMount(): void {
-    /* istanbul ignore next */
+    /* istanbul ignore next -- @preserve */
     document.addEventListener('keydown', this.handleKeyDown);
     document.addEventListener('keyup', this.handleKeyUp);
     window.addEventListener('keydown', this.handleWindowKeyDown);

--- a/src/components/canvas/helpers.ts
+++ b/src/components/canvas/helpers.ts
@@ -12,7 +12,7 @@ import mutate from 'immutability-helper';
 
 export const collides = (a: FlowPosition, b: FlowPosition, fudge: number) => {
   // don't bother with collision if we don't have full dimensions
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   if (!a.bottom || !b.bottom) {
     return false;
   }

--- a/src/components/flow/Flow.tsx
+++ b/src/components/flow/Flow.tsx
@@ -183,7 +183,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
 
     this.Plumber = new Plumber();
 
-    /* istanbul ignore next */
+    /* istanbul ignore next -- @preserve */
     if (context.config.debug) {
       window.fe = new Debug(props, this.props.debug);
     }
@@ -291,7 +291,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
       this.props.mergeEditorState({ ghostNode: null });
     }
 
-    /* istanbul ignore next */
+    /* istanbul ignore next -- @preserve */
     document.removeEventListener('mousemove', (window as any).ghostListener);
 
     return true;
@@ -620,7 +620,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({
   flowContext: { definition, nodes, search },
   editorState: {
@@ -647,7 +647,7 @@ const mapStateToProps = ({
   };
 };
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators(
     {

--- a/src/components/flow/actions/action/Action.tsx
+++ b/src/components/flow/actions/action/Action.tsx
@@ -245,7 +245,7 @@ export class ActionWrapper extends React.Component<ActionWrapperProps> {
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({
   flowContext: {
     definition: { localization },
@@ -259,7 +259,7 @@ const mapStateToProps = ({
   mouseState,
 });
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators(
     {

--- a/src/components/flow/actions/callbrain/CallBrainForm.tsx
+++ b/src/components/flow/actions/callbrain/CallBrainForm.tsx
@@ -123,7 +123,7 @@ export class BrainForm extends React.Component<
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({ flowContext: { brainInfo } }: AppState) => {
   return {
     brainInfo,

--- a/src/components/flow/actions/missing/Missing.tsx
+++ b/src/components/flow/actions/missing/Missing.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Action } from 'flowTypes';
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const MissingComp: React.SFC<Action> = ({ type }: Action): JSX.Element => {
   return <div className="placeholder">No implementation yet for {type}</div>;
 };

--- a/src/components/flow/actions/whatsapp/sendmsg/OptionsList.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/OptionsList.tsx
@@ -164,7 +164,7 @@ export default class OptionsList extends React.Component<OptionsListProps> {
     this.props.onOptionRemoval(item);
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   private handleListItemsSortEnd({ oldIndex, newIndex }: SortEnd): void {
     const options = this.props.options.value;
     const listItems = arrayMove(
@@ -198,7 +198,7 @@ export default class OptionsList extends React.Component<OptionsListProps> {
                   value={{ item: value, list: this, length: items.length }}
                   disabled={index === this.props.options.value.length - 1}
                   shouldCancelStart={
-                    /* istanbul ignore next */
+                    /* istanbul ignore next -- @preserve */
                     (e: any) => {
                       console.log(e);
                       return true;
@@ -230,7 +230,7 @@ export default class OptionsList extends React.Component<OptionsListProps> {
             onSortEnd={this.handleListItemsSortEnd}
             helperClass={styles.item_z_index}
             shouldCancelStart={
-              /* istanbul ignore next */
+              /* istanbul ignore next -- @preserve */
               (e: React.MouseEvent<HTMLDivElement>) => {
                 if (e.target.constructor.name === 'SVGSVGElement') {
                   return !(e.target as any).dataset.draggable;

--- a/src/components/flow/actions/whatsapp/sendmsg/QuickRepliesList.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/QuickRepliesList.tsx
@@ -116,7 +116,7 @@ export default class QuickRepliesList extends React.Component<
     this.props.onQuickRepliesUpdated(quickReplies);
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   private handleRepliesSortEnd({ oldIndex, newIndex }: SortEnd): void {
     const quickReplies = arrayMove(
       this.props.quickReplies.value,
@@ -152,7 +152,7 @@ export default class QuickRepliesList extends React.Component<
                     hasEmptyReply(this.props.quickReplies.value)
                   }
                   shouldCancelStart={
-                    /* istanbul ignore next */
+                    /* istanbul ignore next -- @preserve */
                     (e: any) => {
                       console.log(e);
                       return true;
@@ -183,7 +183,7 @@ export default class QuickRepliesList extends React.Component<
           onSortEnd={this.handleRepliesSortEnd}
           helperClass={styles.item_z_index}
           shouldCancelStart={
-            /* istanbul ignore next */
+            /* istanbul ignore next -- @preserve */
             (e: React.MouseEvent<HTMLDivElement>) => {
               if (e.target.constructor.name === 'SVGSVGElement') {
                 return !(e.target as any).dataset.draggable;

--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -191,7 +191,7 @@ export class NodeComp extends React.PureComponent<NodeProps> {
     this.props.plumberRemove(this.props.renderNode.node.uuid);
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   private handleUUIDClicked(event: React.MouseEvent<HTMLElement>): void {
     const selection = window.getSelection();
     const range = document.createRange();
@@ -255,7 +255,7 @@ export class NodeComp extends React.PureComponent<NodeProps> {
     return this.props.startingNode;
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   private renderDebug(): JSX.Element {
     if (this.props.debug) {
       if (this.props.debug.showUUIDs) {

--- a/src/components/form/checkbox/CheckboxElement.tsx
+++ b/src/components/form/checkbox/CheckboxElement.tsx
@@ -71,7 +71,7 @@ export default class CheckboxElement extends React.Component<
     });
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   public validate(): boolean {
     return true;
   }

--- a/src/components/form/switch/SwitchElement.tsx
+++ b/src/components/form/switch/SwitchElement.tsx
@@ -54,7 +54,7 @@ export default class SwitchElement extends React.Component<
     });
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   public validate(): boolean {
     return true;
   }

--- a/src/components/guidingsteps/GuidingSteps.tsx
+++ b/src/components/guidingsteps/GuidingSteps.tsx
@@ -106,7 +106,7 @@ export class GuidingSteps extends React.Component<
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({
   editorState: { currentGuide, guidingStep },
 }: AppState) => {
@@ -115,7 +115,7 @@ const mapStateToProps = ({
     guidingStep,
   };
 };
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators({ mergeEditorState }, dispatch);
 

--- a/src/components/languageselector/LanguageSelector.tsx
+++ b/src/components/languageselector/LanguageSelector.tsx
@@ -88,7 +88,7 @@ export class LanguageSelector extends React.Component<LanguageSelectorProps> {
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({
   flowContext: { assetStore },
   editorState: { language },
@@ -97,7 +97,7 @@ const mapStateToProps = ({
   language,
 });
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators(
     {

--- a/src/components/nodeeditor/NodeEditor.tsx
+++ b/src/components/nodeeditor/NodeEditor.tsx
@@ -199,7 +199,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({
   flowContext: { nodes, assetStore, issues },
   editorState: { language, translating },
@@ -216,7 +216,7 @@ const mapStateToProps = ({
   };
 };
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators(
     {

--- a/src/components/revisions/RevisionExplorer.tsx
+++ b/src/components/revisions/RevisionExplorer.tsx
@@ -232,7 +232,7 @@ export class RevisionExplorer extends React.Component<
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({ flowContext: { assetStore } }: AppState) => ({
   assetStore: assetStore,
 });

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -333,7 +333,7 @@ const mapStateToProps = ({ flowContext: { search, nodes } }: AppState) => {
   };
 };
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators({ handleSearchChange, onUpdateCanvasPositions }, dispatch);
 

--- a/src/components/simulator/Simulator.tsx
+++ b/src/components/simulator/Simulator.tsx
@@ -1274,7 +1274,7 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({
   flowContext: { definition, nodes },
   editorState: { liveActivity, activity, language },
@@ -1286,7 +1286,7 @@ const mapStateToProps = ({
   language,
 });
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) =>
   bindActionCreators({}, dispatch);
 

--- a/src/components/sticky/Sticky.tsx
+++ b/src/components/sticky/Sticky.tsx
@@ -268,10 +268,10 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = () => ({});
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapDispatchToProps = (dispatch: DispatchWithState) => {
   return bindActionCreators({ updateSticky }, dispatch);
 };

--- a/src/services/Plumber.ts
+++ b/src/services/Plumber.ts
@@ -81,7 +81,7 @@ const defaultConnector = [
   },
 ];
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 export default class Plumber {
   public jsPlumb: any;
 

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -333,7 +333,7 @@ export const getCollisions = (
 
 export const collides = (a: FlowPosition, b: FlowPosition) => {
   // don't bother with collision if we don't have full dimensions
-  /* istanbul ignore next */
+  /* istanbul ignore next -- @preserve */
   if (!a.bottom || !b.bottom) {
     return false;
   }

--- a/src/temba/TembaCompletion.tsx
+++ b/src/temba/TembaCompletion.tsx
@@ -278,7 +278,7 @@ export class TembaCompletion extends React.Component<
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({ flowContext: { assetStore } }: AppState) => ({
   expressionsData: assetStore.completion.items as any,
 });

--- a/src/temba/TembaSelect.tsx
+++ b/src/temba/TembaSelect.tsx
@@ -768,7 +768,7 @@ export class TembaSelect extends React.Component<
   }
 }
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 const mapStateToProps = ({ flowContext: { assetStore } }: AppState) => ({
   expressionsData: assetStore.completion.items as any,
 });

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -3,7 +3,7 @@ import { DebugState } from 'store/editor';
 
 import mutate from 'immutability-helper';
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 export default class Debug {
   private props: FlowStoreProps;
   private state: DebugState;

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -316,11 +316,11 @@ export const isValidLabel = (label: string) =>
 
 export const isRealValue = (obj: any) => obj !== null && obj !== undefined;
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 export const timeStart = (name: string) =>
   process.env.NODE_ENV === 'development' && console.time(name);
 
-/* istanbul ignore next */
+/* istanbul ignore next -- @preserve */
 export const timeEnd = (name: string) =>
   process.env.NODE_ENV === 'development' && console.timeEnd(name);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 import path from 'path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
@@ -49,6 +49,13 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['lcov', 'text', 'html'],
       reportsDirectory: './coverage',
+      exclude: [
+        '__mocks__/**',
+        'utils/**',
+        'testUtils/**',
+        'services/__mocks__/**',
+        ...coverageConfigDefaults.exclude,
+      ],
     },
   },
   build: {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [X] Tests
* * [ ] Other

### Motivation and Context
Increase floweditor test coverage

### Summary of Changes
Vitest requires @preserve to be present in ignore next comments, added them to existing ignore next comments
