### PR TITLE
fix: show new variables if not in existing action flow_data

### DIFF
--- a/src/components/flow/actions/whatsapp/sendmsg/helpers.ts
+++ b/src/components/flow/actions/whatsapp/sendmsg/helpers.ts
@@ -43,6 +43,7 @@ export const nodeToState = (
     }
 
     let whatsAppFlow: WhatsAppFlow = null;
+    const whatsAppFlowData = action.flow_data;
     const whatsAppFlowAsset = assetStore.whatsapp_flows.items[action.flow_id];
     if (whatsAppFlowAsset) {
       whatsAppFlow = {
@@ -50,6 +51,15 @@ export const nodeToState = (
         name: whatsAppFlowAsset.name,
         assets: whatsAppFlowAsset.content.assets,
       };
+
+      // add newer variables if needed
+      if (whatsAppFlowData) {
+        whatsAppFlow.assets.variables.forEach(key => {
+          if (!whatsAppFlowData[key]) {
+            whatsAppFlowData[key] = '';
+          }
+        });
+      }
     }
 
     return {
@@ -83,7 +93,7 @@ export const nodeToState = (
       quickReplyEntry: { value: '' },
       valid: true,
       whatsappFlow: { value: whatsAppFlow },
-      flowData: { value: action.flow_data || null },
+      flowData: { value: whatsAppFlowData || null },
       flowScreen: { value: action.flow_screen || '' },
       flowDataAttachmentNameMap: action.flow_data_attachment_name_map || {},
     };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When newer variables were added to the whatsapp flow, and the card was already configured, the newer ones would not appear in the flow data list

### Summary of Changes
Handled new keys to be added in the flow data state
