### PR TITLE
fix: handle undefined list_items in localizations

### DIFF
--- a/src/components/flow/actions/localization/helpers.ts
+++ b/src/components/flow/actions/localization/helpers.ts
@@ -147,13 +147,15 @@ export const initializeWhatsappMsgLocalizedForm = (
     buttonText: { value: '' },
     actionURL: { value: '' },
     listItems: {
-      value: (originalAction as SendWhatsAppMsg).list_items.map(item => {
-        return {
-          uuid: item.uuid,
-          title: '',
-          description: '',
-        };
-      }),
+      value: ((originalAction as SendWhatsAppMsg).list_items || []).map(
+        item => {
+          return {
+            uuid: item.uuid,
+            title: '',
+            description: '',
+          };
+        },
+      ),
     },
     listItemTitleEntry: { value: '' },
     listItemDescriptionEntry: { value: '' },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Localizations without list_items were not being rendered

### Summary of Changes
Handled undefined list_items in localization form
