### PR TITLE
feat: add dynamic input length handling for WhatsApp message components

### DIFF
--- a/src/components/flow/actions/whatsapp/sendmsg/OptionsList.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/OptionsList.tsx
@@ -18,6 +18,7 @@ import {
   arrayMove,
 } from 'react-sortable-hoc';
 import { WhatsAppListItem } from 'components/flow/actions/whatsapp/sendmsg/SendWhatsAppMsgForm';
+import { getMaxInputLength } from 'components/flow/actions/whatsapp/sendmsg/helpers';
 import { MAX_LIST_ITEMS_COUNT } from 'components/flow/actions/whatsapp/sendmsg/constants';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import update from 'immutability-helper';
@@ -64,6 +65,14 @@ export function hasEmptyListItem(listItems: WhatsAppListItem[]): boolean {
 }
 
 const SortableListItem = SortableElement(({ value: row, index }: any) => {
+  const MAX_TITLE_LENGTH = 24;
+  const MAX_DESCRIPTION_LENGTH = 72;
+  const maxTitleLength = getMaxInputLength(row.item, MAX_TITLE_LENGTH);
+  const maxDescriptionLength = getMaxInputLength(
+    row.item,
+    MAX_DESCRIPTION_LENGTH,
+  );
+
   const listItem = row.item as WhatsAppListItem;
   return (
     <div className={styles.content}>
@@ -104,7 +113,7 @@ const SortableListItem = SortableElement(({ value: row, index }: any) => {
             entry={{ value: listItem.title }}
             autocomplete={true}
             showLabel={true}
-            maxLength={24}
+            maxLength={maxTitleLength}
           />
 
           <TextInputElement
@@ -123,7 +132,7 @@ const SortableListItem = SortableElement(({ value: row, index }: any) => {
             entry={{ value: listItem.description }}
             autocomplete={true}
             showLabel={true}
-            maxLength={72}
+            maxLength={maxDescriptionLength}
           />
 
           <UnnnicButton

--- a/src/components/flow/actions/whatsapp/sendmsg/QuickRepliesList.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/QuickRepliesList.tsx
@@ -14,6 +14,7 @@ import {
 import TextInputElement, {
   TextInputSizes,
 } from 'components/form/textinput/TextInputElement';
+import { getMaxInputLength } from 'components/flow/actions/whatsapp/sendmsg/helpers';
 import update from 'immutability-helper';
 import { applyVueInReact } from 'veaury';
 // @ts-ignore
@@ -47,6 +48,9 @@ export function hasEmptyReply(replies: string[]): boolean {
 }
 
 const SortableReply = SortableElement(({ value: row, index }: any) => {
+  const MAX_REPLY_LENGTH = 20;
+  const maxLength = getMaxInputLength(row.item, MAX_REPLY_LENGTH);
+
   return (
     <div className={styles.reply_item_wrapper}>
       <div className={styles.drag_wrapper} data-draggable={true}>
@@ -71,7 +75,7 @@ const SortableReply = SortableElement(({ value: row, index }: any) => {
           entry={{ value: row.item }}
           autocomplete={true}
           showLabel={false}
-          maxLength={20}
+          maxLength={maxLength}
         />
       </div>
 

--- a/src/components/flow/actions/whatsapp/sendmsg/SendWhatsAppMsgForm.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/SendWhatsAppMsgForm.tsx
@@ -4,6 +4,7 @@ import {
   nodeToState,
   stateToAction,
   createEmptyListItem,
+  getMaxInputLength,
 } from 'components/flow/actions/whatsapp/sendmsg/helpers';
 import { ActionFormProps } from 'components/flow/props';
 import TextInputElement, {
@@ -963,7 +964,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 placeholder={i18n.t('forms.header_text', 'Header text')}
                 size={TextInputSizes.sm}
                 autocomplete={true}
-                maxLength={60}
+                maxLength={getMaxInputLength(this.state.headerText, 60)}
               />
             </div>,
           )}
@@ -1088,7 +1089,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 onChange={this.handleButtonTextUpdate}
                 entry={this.state.buttonText}
                 autocomplete={true}
-                maxLength={20}
+                maxLength={getMaxInputLength(this.state.buttonText, 20)}
               />
             </div>
           )}
@@ -1106,7 +1107,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 entry={this.state.flowScreen}
                 autocomplete={true}
                 showLabel={true}
-                maxLength={20}
+                maxLength={getMaxInputLength(this.state.flowScreen, 20)}
               />
             </div>
           )}
@@ -1129,7 +1130,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 entry={this.state.buttonText}
                 autocomplete={true}
                 showLabel={true}
-                maxLength={24}
+                maxLength={getMaxInputLength(this.state.buttonText, 24)}
               />
             </div>
             <div>

--- a/src/components/flow/actions/whatsapp/sendmsg/helpers.ts
+++ b/src/components/flow/actions/whatsapp/sendmsg/helpers.ts
@@ -196,3 +196,11 @@ export const createEmptyListItem = () => {
     description: '',
   };
 };
+
+export const getMaxInputLength = (reply: any, defaultLength: number) => {
+  if (typeof reply === 'string') {
+    return reply.indexOf('@') > -1 ? undefined : defaultLength;
+  }
+
+  return defaultLength;
+};


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When expressions are used, usually they can pass the input length, but we should allow these behaviors

### Summary of Changes
- Introduced `getMaxInputLength` helper function to determine maximum input lengths based on reply content.
- Updated `OptionsList`, `QuickRepliesList`, and `SendWhatsAppMsgForm` components to utilize dynamic max length for text inputs.
