### PR TITLE
fix: getMaxInputLength usage in WhatsApp message components

### DIFF
--- a/src/components/flow/actions/whatsapp/sendmsg/OptionsList.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/OptionsList.tsx
@@ -67,13 +67,14 @@ export function hasEmptyListItem(listItems: WhatsAppListItem[]): boolean {
 const SortableListItem = SortableElement(({ value: row, index }: any) => {
   const MAX_TITLE_LENGTH = 24;
   const MAX_DESCRIPTION_LENGTH = 72;
-  const maxTitleLength = getMaxInputLength(row.item, MAX_TITLE_LENGTH);
-  const maxDescriptionLength = getMaxInputLength(
-    row.item,
-    MAX_DESCRIPTION_LENGTH,
-  );
 
   const listItem = row.item as WhatsAppListItem;
+
+  const maxTitleLength = getMaxInputLength(listItem.title, MAX_TITLE_LENGTH);
+  const maxDescriptionLength = getMaxInputLength(
+    listItem.description,
+    MAX_DESCRIPTION_LENGTH,
+  );
   return (
     <div className={styles.content}>
       <div className={styles.drag_wrapper} data-draggable={true}>

--- a/src/components/flow/actions/whatsapp/sendmsg/SendWhatsAppMsgForm.tsx
+++ b/src/components/flow/actions/whatsapp/sendmsg/SendWhatsAppMsgForm.tsx
@@ -964,7 +964,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 placeholder={i18n.t('forms.header_text', 'Header text')}
                 size={TextInputSizes.sm}
                 autocomplete={true}
-                maxLength={getMaxInputLength(this.state.headerText, 60)}
+                maxLength={getMaxInputLength(this.state.headerText.value, 60)}
               />
             </div>,
           )}
@@ -1089,7 +1089,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 onChange={this.handleButtonTextUpdate}
                 entry={this.state.buttonText}
                 autocomplete={true}
-                maxLength={getMaxInputLength(this.state.buttonText, 20)}
+                maxLength={getMaxInputLength(this.state.buttonText.value, 20)}
               />
             </div>
           )}
@@ -1107,7 +1107,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 entry={this.state.flowScreen}
                 autocomplete={true}
                 showLabel={true}
-                maxLength={getMaxInputLength(this.state.flowScreen, 20)}
+                maxLength={getMaxInputLength(this.state.flowScreen.value, 20)}
               />
             </div>
           )}
@@ -1130,7 +1130,7 @@ export default class SendWhatsAppMsgForm extends React.Component<
                 entry={this.state.buttonText}
                 autocomplete={true}
                 showLabel={true}
-                maxLength={getMaxInputLength(this.state.buttonText, 24)}
+                maxLength={getMaxInputLength(this.state.buttonText.value, 24)}
               />
             </div>
             <div>

--- a/src/components/flow/actions/whatsapp/sendmsg/helpers.ts
+++ b/src/components/flow/actions/whatsapp/sendmsg/helpers.ts
@@ -197,7 +197,7 @@ export const createEmptyListItem = () => {
   };
 };
 
-export const getMaxInputLength = (reply: any, defaultLength: number) => {
+export const getMaxInputLength = (reply: string, defaultLength: number) => {
   if (typeof reply === 'string') {
     return reply.indexOf('@') > -1 ? undefined : defaultLength;
   }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some input length validation were using the incorrect value to compare with.

### Summary of Changes
- Updated `getMaxInputLength` helper function explicitly receive an string.
- Updated `OptionsList` and `SendWhatsAppMsgForm` components to utilize pass the correct input value.
